### PR TITLE
fix: Adapt 'About' menu path for GNOME 46.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -8,6 +8,7 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as Util from 'resource:///org/gnome/shell/misc/util.js';
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 
 import * as Constants from './constants.js';
 import * as Selection from './selection.js';
@@ -125,7 +126,12 @@ class LogoMenuMenuButton extends PanelMenu.Button {
     }
 
     _aboutThisDistro() {
-        Util.spawn(['gnome-control-center', 'info-overview']);
+        const gnomeMajorVersion = parseInt(Config.PACKAGE_VERSION.toString().split('.')[0]);
+        if (gnomeMajorVersion >= 46) {
+            Util.spawn(['gnome-control-center', 'system', 'about']);
+        } else {
+            Util.spawn(['gnome-control-center', 'info-overview']);
+        }
     }
 
     _systemPreferences() {


### PR DESCRIPTION
There was some menu mangling from GNOME 45 to 46. On Bluefin 40, "Logomenu > About My System" fails to open the nice "About" detail window, instead it just opens the last used Settings detail window. Newcomers to Bluefin might enjoy this working properly :-)

`gnome-control-center --list` shows several differences. `info-overview` got replaced by `system` subpanel `about`.

| Bluefin 39 / GNOME 45 | Bluefin 40 / GNOME 46 |
|--------------------|--------------------|
| applications | applications |
| background | background |
| bluetooth | bluetooth |
| color | color |
| datetime | |
| default-apps | |
| display | display |
| **info-overview** | |
| keyboard | keyboard |
| mouse | mouse |
| multitasking | multitasking |
| network | network |
| wifi | wifi |
| notifications | notifications |
| online-accounts | online-accounts |
| power | power |
| printers | printers |
| privacy | privacy |
| region | |
| removable-media | |
| search | search |
| sharing | sharing |
| sound | sound |
| | **system**  |
| universal-access | universal-access |
| user-accounts | |
| wacom | wacom |
| wwan | wwan |

Related to this https://github.com/GNOME/gnome-control-center/commit/fb13e45ababeb2874da150eb21aea609883e6bee


