### PR TITLE
general: Add documentation entry

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -75,17 +75,17 @@ class LogoMenuMenuButton extends PanelMenu.Button {
         this.menu.removeAll();
 
         this._addItem(new MenuItem(_('About My System'), () => this._aboutThisDistro()));
-        this._addItem(new MenuItem(_('System Settings...'), () => this._systemPreferences()));
         this._addItem(new PopupMenu.PopupSeparatorMenuItem());
+
+        this._addItem(new MenuItem(_('System Settings...'), () => this._systemPreferences()));
 
         if (!showActivitiesButton)
             this._addItem(new MenuItem(_('Activities'), () => this._overviewToggle()));
 
         // this._addItem(new MenuItem(_('App Grid'), () => this._showAppGrid()));
-        this._addItem(new PopupMenu.PopupSeparatorMenuItem());
-
         if (showSoftwareCenter)
             this._addItem(new MenuItem(_('Software Center'), () => this._openSoftwareCenter()));
+        this._addItem(new PopupMenu.PopupSeparatorMenuItem());
 
         this._addItem(new MenuItem(_('System Monitor'), () => this._openSystemMonitor()));
         this._addItem(new MenuItem(_('Terminal'), () => this._openTerminal()));

--- a/extension.js
+++ b/extension.js
@@ -85,7 +85,7 @@ class LogoMenuMenuButton extends PanelMenu.Button {
         this._addItem(new PopupMenu.PopupSeparatorMenuItem());
 
         if (showSoftwareCenter)
-            this._addItem(new MenuItem(_('Software Center...'), () => this._openSoftwareCenter()));
+            this._addItem(new MenuItem(_('Software Center'), () => this._openSoftwareCenter()));
 
         this._addItem(new MenuItem(_('System Monitor'), () => this._openSystemMonitor()));
         this._addItem(new MenuItem(_('Terminal'), () => this._openTerminal()));

--- a/extension.js
+++ b/extension.js
@@ -91,6 +91,8 @@ class LogoMenuMenuButton extends PanelMenu.Button {
         this._addItem(new MenuItem(_('Extensions'), () => this._openExtensionsApp()));
         this._addItem(new MenuItem(_('System Monitor'), () => this._openSystemMonitor()));
         this._addItem(new MenuItem(_('Terminal'), () => this._openTerminal()));
+        this._addItem(new PopupMenu.PopupSeparatorMenuItem());
+
         if (showBoxBuddy)
             this._addItem(new MenuItem(_('Containers'), () => this._openBoxBuddy()));
 

--- a/extension.js
+++ b/extension.js
@@ -75,6 +75,7 @@ class LogoMenuMenuButton extends PanelMenu.Button {
         this.menu.removeAll();
 
         this._addItem(new MenuItem(_('About My System'), () => this._aboutThisDistro()));
+        this._addItem(new MenuItem(_('Documentation'), () => this._documentation()));
         this._addItem(new PopupMenu.PopupSeparatorMenuItem());
 
         this._addItem(new MenuItem(_('System Settings...'), () => this._systemPreferences()));
@@ -135,6 +136,10 @@ class LogoMenuMenuButton extends PanelMenu.Button {
 
     _systemPreferences() {
         Util.spawn(['gnome-control-center']);
+    }
+
+    _documentation() {
+        Util.trySpawnCommandLine('xdg-open https://docs.projectbluefin.io/')
     }
 
     _overviewToggle() {

--- a/extension.js
+++ b/extension.js
@@ -75,7 +75,7 @@ class LogoMenuMenuButton extends PanelMenu.Button {
         this.menu.removeAll();
 
         this._addItem(new MenuItem(_('About My System'), () => this._aboutThisDistro()));
-        // this._addItem(new MenuItem(_('System Settings...'), () => this._systemPreferences()));
+        this._addItem(new MenuItem(_('System Settings...'), () => this._systemPreferences()));
         this._addItem(new PopupMenu.PopupSeparatorMenuItem());
 
         if (!showActivitiesButton)

--- a/extension.js
+++ b/extension.js
@@ -81,7 +81,7 @@ class LogoMenuMenuButton extends PanelMenu.Button {
         if (!showActivitiesButton)
             this._addItem(new MenuItem(_('Activities'), () => this._overviewToggle()));
 
-        this._addItem(new MenuItem(_('App Grid'), () => this._showAppGrid()));
+        // this._addItem(new MenuItem(_('App Grid'), () => this._showAppGrid()));
         this._addItem(new PopupMenu.PopupSeparatorMenuItem());
 
         if (showSoftwareCenter)

--- a/extension.js
+++ b/extension.js
@@ -87,12 +87,11 @@ class LogoMenuMenuButton extends PanelMenu.Button {
             this._addItem(new MenuItem(_('Software Center'), () => this._openSoftwareCenter()));
         this._addItem(new PopupMenu.PopupSeparatorMenuItem());
 
+        this._addItem(new MenuItem(_('Extensions'), () => this._openExtensionsApp()));
         this._addItem(new MenuItem(_('System Monitor'), () => this._openSystemMonitor()));
         this._addItem(new MenuItem(_('Terminal'), () => this._openTerminal()));
         if (showBoxBuddy)
             this._addItem(new MenuItem(_('Containers'), () => this._openBoxBuddy()));
-
-        this._addItem(new MenuItem(_('Extensions'), () => this._openExtensionsApp()));
 
         if (showForceQuit) {
             this._addItem(new PopupMenu.PopupSeparatorMenuItem());

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,6 @@
   "shell-version": ["46", "47"],
   "url": "https://github.com/Aryan20/Logomenu",
   "uuid": "logomenu@aryan_k",
-  "version": 33,
-  "version-name": "23.4"
+  "version": 34,
+  "version-name": "23.6"
 }

--- a/po/be.po
+++ b/po/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Logo Menu 18\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 05:04+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: 2022-11-17 23:23+0530\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -31,9 +31,9 @@ msgstr "Агляд"
 msgid "App Grid"
 msgstr "Праграмы"
 
-#: extension.js:86
-msgid "Software Center..."
-msgstr "Менеджар праграм..."
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
+msgstr "Менеджар праграм"
 
 #: extension.js:88 PrefsLib/adw.js:332
 msgid "System Monitor"
@@ -139,10 +139,6 @@ msgstr ""
 msgid "Extensions Manager"
 msgstr ""
 
-#: PrefsLib/adw.js:314
-msgid "Software Center"
-msgstr "Менеджар праграм"
-
 #: PrefsLib/adw.js:350
 msgid "Enable Power Options"
 msgstr "Уключыць опцыі сілкавання"
@@ -208,6 +204,9 @@ msgstr ""
 #, javascript-format
 msgid "See the %sGNU General Public License, version 2 or later%s for details."
 msgstr ""
+
+#~ msgid "Software Center..."
+#~ msgstr "Менеджар праграм..."
 
 #~ msgid "Github"
 #~ msgstr "Github"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Logo Menu 18\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 05:04+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: 2023-07-07 11:54+0200\n"
 "Last-Translator: @jcatfor\n"
 "Language-Team: Catalan\n"
@@ -31,9 +31,9 @@ msgstr "Activitats"
 msgid "App Grid"
 msgstr "Aplicacions"
 
-#: extension.js:86
-msgid "Software Center..."
-msgstr "Programari..."
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
+msgstr "Programari"
 
 #: extension.js:88 PrefsLib/adw.js:332
 msgid "System Monitor"
@@ -139,10 +139,6 @@ msgstr "Extensions del GNOME"
 msgid "Extensions Manager"
 msgstr "Gestor d'Extensions"
 
-#: PrefsLib/adw.js:314
-msgid "Software Center"
-msgstr "Programari"
-
 #: PrefsLib/adw.js:350
 msgid "Enable Power Options"
 msgstr "Activa les Opcions per al Reinici i Apagat"
@@ -208,6 +204,9 @@ msgstr ""
 #, javascript-format
 msgid "See the %sGNU General Public License, version 2 or later%s for details."
 msgstr ""
+
+#~ msgid "Software Center..."
+#~ msgstr "Programari..."
 
 #~ msgid "Github"
 #~ msgstr "Github"

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Logo Menu 22.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 05:04+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: 2024-04-26 18:45+2\n"
 "Last-Translator: Karel Mašek <masekkarel@vivaldi.net>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -29,9 +29,9 @@ msgstr "Aktivity"
 msgid "App Grid"
 msgstr "Aplikace"
 
-#: extension.js:86
-msgid "Software Center..."
-msgstr "Software..."
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
+msgstr "Software"
 
 #: extension.js:88 PrefsLib/adw.js:332
 msgid "System Monitor"
@@ -137,10 +137,6 @@ msgstr "GNOME Rozšíření"
 msgid "Extensions Manager"
 msgstr "Správce rozšíření"
 
-#: PrefsLib/adw.js:314
-msgid "Software Center"
-msgstr "Software"
-
 #: PrefsLib/adw.js:350
 msgid "Enable Power Options"
 msgstr "Zobrazit možnosti napájení"
@@ -206,3 +202,6 @@ msgstr "Na tento program se nevztahuje žádná záruka."
 msgid "See the %sGNU General Public License, version 2 or later%s for details."
 msgstr ""
 "Tento software spadá pod %sGNU General Public License, version 2 or later%s."
+
+#~ msgid "Software Center..."
+#~ msgstr "Software..."

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Logo Menu 18\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 05:04+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: 2022-11-17 23:23+0530\n"
 "Last-Translator: Heinz J. Malcharzyk <trurl.klapauzius@t-online.de>\n"
 "Language-Team: German <trurl.klapauzius@t-online.de>\n"
@@ -31,8 +31,8 @@ msgstr "Aktivitäten"
 msgid "App Grid"
 msgstr "Programmübersicht"
 
-#: extension.js:86
-msgid "Software Center..."
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
 msgstr "Software-Center"
 
 #: extension.js:88 PrefsLib/adw.js:332
@@ -140,10 +140,6 @@ msgstr "GNOME Extensions"
 msgid "Extensions Manager"
 msgstr "Extensions Manager"
 
-#: PrefsLib/adw.js:314
-msgid "Software Center"
-msgstr "Software-Center"
-
 #: PrefsLib/adw.js:350
 msgid "Enable Power Options"
 msgstr "Energie-Optionen aktivieren"
@@ -209,6 +205,9 @@ msgstr ""
 #, javascript-format
 msgid "See the %sGNU General Public License, version 2 or later%s for details."
 msgstr ""
+
+#~ msgid "Software Center..."
+#~ msgstr "Software-Center"
 
 #~ msgid "Github"
 #~ msgstr "Github"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Logo Menu 18\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 05:04+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: 2023-12-10 17:32-0600\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
 "Language-Team: Spanish\n"
@@ -32,9 +32,9 @@ msgstr "Actividades"
 msgid "App Grid"
 msgstr "Aplicaciones"
 
-#: extension.js:86
-msgid "Software Center..."
-msgstr "Centro de aplicaciones…"
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
+msgstr "Centro de aplicaciones"
 
 #: extension.js:88 PrefsLib/adw.js:332
 msgid "System Monitor"
@@ -140,10 +140,6 @@ msgstr "Extensiones de GNOME"
 msgid "Extensions Manager"
 msgstr "Gestor de extensiones"
 
-#: PrefsLib/adw.js:314
-msgid "Software Center"
-msgstr "Centro de aplicaciones"
-
 #: PrefsLib/adw.js:350
 msgid "Enable Power Options"
 msgstr "Activar opciones de energía"
@@ -210,3 +206,6 @@ msgid "See the %sGNU General Public License, version 2 or later%s for details."
 msgstr ""
 "Consulte la %sLicencia Pública General de GNU, versión 2 o posterior%s para "
 "conocer más."
+
+#~ msgid "Software Center..."
+#~ msgstr "Centro de aplicaciones…"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Logo Menu 18\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 05:04+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: 2022-11-17 23:23+0530\n"
 "Last-Translator: Irénée Thirion <irenee.thirion@e.email>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -29,9 +29,9 @@ msgstr "Activités"
 msgid "App Grid"
 msgstr "Grille d’applications"
 
-#: extension.js:86
-msgid "Software Center..."
-msgstr "Centre de logiciels..."
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
+msgstr "Centre de logiciels"
 
 #: extension.js:88 PrefsLib/adw.js:332
 msgid "System Monitor"
@@ -137,10 +137,6 @@ msgstr "Extensions de GNOME"
 msgid "Extensions Manager"
 msgstr "Gestionnaire d'extensions"
 
-#: PrefsLib/adw.js:314
-msgid "Software Center"
-msgstr "Centre de logiciels"
-
 #: PrefsLib/adw.js:350
 msgid "Enable Power Options"
 msgstr "Activer les options d’alimentation"
@@ -206,6 +202,9 @@ msgstr ""
 #, javascript-format
 msgid "See the %sGNU General Public License, version 2 or later%s for details."
 msgstr ""
+
+#~ msgid "Software Center..."
+#~ msgstr "Centre de logiciels..."
 
 #~ msgid "Github"
 #~ msgstr "Github"

--- a/po/hu.po
+++ b/po/hu.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Logo Menu 23.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 05:04+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: 2024-07-22 22:08+0200\n"
 "Last-Translator: Tamás\n"
 "Language-Team: \n"
@@ -30,8 +30,8 @@ msgstr "Tevékenységek"
 msgid "App Grid"
 msgstr "Alkalmazás rács"
 
-#: extension.js:86
-msgid "Software Center..."
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
 msgstr "Alkalmazás Áruház"
 
 #: extension.js:88 PrefsLib/adw.js:332
@@ -138,10 +138,6 @@ msgstr "GNOME kiegészítők"
 msgid "Extensions Manager"
 msgstr "Kiegészítők Kezelő"
 
-#: PrefsLib/adw.js:314
-msgid "Software Center"
-msgstr "Alkalmazás Áruház"
-
 #: PrefsLib/adw.js:350
 msgid "Enable Power Options"
 msgstr "Energia opciók engedélyezése"
@@ -205,4 +201,9 @@ msgstr "Ez a program semmilyen szavatossággal nem rendelkezik."
 #: PrefsLib/adw.js:584
 #, javascript-format
 msgid "See the %sGNU General Public License, version 2 or later%s for details."
-msgstr "Lásd a %sGNU General Public License 2-es verziót vagy későbbit%s a részletekért."
+msgstr ""
+"Lásd a %sGNU General Public License 2-es verziót vagy későbbit%s a "
+"részletekért."
+
+#~ msgid "Software Center..."
+#~ msgstr "Alkalmazás Áruház"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Logo Menu 18\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 05:04+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: 2022-11-17 23:21+0530\n"
 "Last-Translator: Igor Calì <igor.cali0@gmail.com>\n"
 "Language-Team: <>\n"
@@ -30,9 +30,9 @@ msgstr "Attività"
 msgid "App Grid"
 msgstr "Griglia applicazioni"
 
-#: extension.js:86
-msgid "Software Center..."
-msgstr "Centro software..."
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
+msgstr "Centro software"
 
 #: extension.js:88 PrefsLib/adw.js:332
 msgid "System Monitor"
@@ -138,10 +138,6 @@ msgstr "Estensioni"
 msgid "Extensions Manager"
 msgstr "Gestore di estensioni"
 
-#: PrefsLib/adw.js:314
-msgid "Software Center"
-msgstr "Centro software"
-
 #: PrefsLib/adw.js:350
 msgid "Enable Power Options"
 msgstr "Abilità opzioni alimentazione"
@@ -206,7 +202,12 @@ msgstr "Questo programma è fornito senza alcuna garanzia."
 #: PrefsLib/adw.js:584
 #, javascript-format
 msgid "See the %sGNU General Public License, version 2 or later%s for details."
-msgstr "Consultare la %sGNU General Public License, versione 2 o successive%s per i dettagli."
+msgstr ""
+"Consultare la %sGNU General Public License, versione 2 o successive%s per i "
+"dettagli."
+
+#~ msgid "Software Center..."
+#~ msgstr "Centro software..."
 
 #~ msgid "Github"
 #~ msgstr "Github"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Logo Menu 18\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 05:04+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: 2022-11-17 23:22+0530\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -30,9 +30,9 @@ msgstr "현재 활동"
 msgid "App Grid"
 msgstr "앱 표시"
 
-#: extension.js:86
-msgid "Software Center..."
-msgstr "소프트웨어..."
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
+msgstr "소프트웨어 센터"
 
 #: extension.js:88 PrefsLib/adw.js:332
 msgid "System Monitor"
@@ -138,10 +138,6 @@ msgstr "그놈 확장"
 msgid "Extensions Manager"
 msgstr "확장 관리자"
 
-#: PrefsLib/adw.js:314
-msgid "Software Center"
-msgstr "소프트웨어 센터"
-
 #: PrefsLib/adw.js:350
 msgid "Enable Power Options"
 msgstr "전원 옵션 사용"
@@ -207,6 +203,9 @@ msgstr ""
 #, javascript-format
 msgid "See the %sGNU General Public License, version 2 or later%s for details."
 msgstr ""
+
+#~ msgid "Software Center..."
+#~ msgstr "소프트웨어..."
 
 #~ msgid "Icon"
 #~ msgstr "아이콘"

--- a/po/main.pot
+++ b/po/main.pot
@@ -1,18 +1,18 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2023 Aryan Kaushik (Aryan20)
+# Copyright (C) 2025 Aryan Kaushik (Aryan20)
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Logo Menu 23.0\n"
+"Project-Id-Version: Logo Menu 34\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 05:04+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language: En\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -29,8 +29,8 @@ msgstr ""
 msgid "App Grid"
 msgstr ""
 
-#: extension.js:86
-msgid "Software Center..."
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
 msgstr ""
 
 #: extension.js:88 PrefsLib/adw.js:332
@@ -135,10 +135,6 @@ msgstr ""
 
 #: PrefsLib/adw.js:282
 msgid "Extensions Manager"
-msgstr ""
-
-#: PrefsLib/adw.js:314
-msgid "Software Center"
 msgstr ""
 
 #: PrefsLib/adw.js:350

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Logo Menu 18\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 05:04+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: 2023-04-30 21:16+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: \n"
@@ -30,9 +30,9 @@ msgstr "Activiteiten"
 msgid "App Grid"
 msgstr "Toepassingsrooster"
 
-#: extension.js:86
-msgid "Software Center..."
-msgstr "Softwarecentrum…"
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
+msgstr "Softwarecentrum"
 
 #: extension.js:88 PrefsLib/adw.js:332
 msgid "System Monitor"
@@ -138,10 +138,6 @@ msgstr "GNOME-uitbreidingen"
 msgid "Extensions Manager"
 msgstr "Uitbreidingenbeheer"
 
-#: PrefsLib/adw.js:314
-msgid "Software Center"
-msgstr "Softwarecentrum"
-
 #: PrefsLib/adw.js:350
 msgid "Enable Power Options"
 msgstr "Afsluitopties tonen"
@@ -207,6 +203,9 @@ msgstr ""
 #, javascript-format
 msgid "See the %sGNU General Public License, version 2 or later%s for details."
 msgstr ""
+
+#~ msgid "Software Center..."
+#~ msgstr "Softwarecentrum…"
 
 #~ msgid "Github"
 #~ msgstr "GitHub"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Logo Menu 18\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 05:04+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: 2022-11-17 23:22+0530\n"
 "Last-Translator: Jorge Braz <jlbmesquita@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <jlbmesquita@gmail.com>\n"
@@ -31,9 +31,9 @@ msgstr "Atividades"
 msgid "App Grid"
 msgstr "Grade de Aplicativos"
 
-#: extension.js:86
-msgid "Software Center..."
-msgstr "Centro de Software..."
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
+msgstr "Centro de Software"
 
 #: extension.js:88 PrefsLib/adw.js:332
 msgid "System Monitor"
@@ -139,10 +139,6 @@ msgstr ""
 msgid "Extensions Manager"
 msgstr ""
 
-#: PrefsLib/adw.js:314
-msgid "Software Center"
-msgstr "Centro de Software"
-
 #: PrefsLib/adw.js:350
 msgid "Enable Power Options"
 msgstr "Ativar Opções de Energia"
@@ -208,6 +204,9 @@ msgstr ""
 #, javascript-format
 msgid "See the %sGNU General Public License, version 2 or later%s for details."
 msgstr ""
+
+#~ msgid "Software Center..."
+#~ msgstr "Centro de Software..."
 
 #~ msgid "Github"
 #~ msgstr "Github"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Logo Menu 18\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 21:10+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: 2022-06-17 21:10+0530\n"
 "Last-Translator: a1exak <a1exak@outlook.com>\n"
 "Language-Team: <>\n"
@@ -31,9 +31,9 @@ msgstr "Обзор"
 msgid "App Grid"
 msgstr "Приложения"
 
-#: extension.js:86
-msgid "Software Center..."
-msgstr "Центр приложений..."
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
+msgstr "Центр приложений"
 
 #: extension.js:88 PrefsLib/adw.js:332
 msgid "System Monitor"
@@ -139,10 +139,6 @@ msgstr "Расширения GNOME"
 msgid "Extensions Manager"
 msgstr "Менеджер расширений"
 
-#: PrefsLib/adw.js:314
-msgid "Software Center"
-msgstr "Центр приложений"
-
 #: PrefsLib/adw.js:350
 msgid "Enable Power Options"
 msgstr "Показать Параметры питания"
@@ -207,6 +203,9 @@ msgstr "Эта программа поставляется без каких-л�
 #, javascript-format
 msgid "See the %sGNU General Public License, version 2 or later%s for details."
 msgstr "Подробнее смотрите %sGNU General Public License, версии 2 или новее%s."
+
+#~ msgid "Software Center..."
+#~ msgstr "Центр приложений..."
 
 #~ msgid "Github"
 #~ msgstr "Github"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Logo Menu 18\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 05:04+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: 2022-11-17 23:23+0530\n"
 "Last-Translator: Taylan TATLI\n"
 "Language-Team: \n"
@@ -30,8 +30,8 @@ msgstr "Etkinlikler"
 msgid "App Grid"
 msgstr "Uygulamalar"
 
-#: extension.js:86
-msgid "Software Center..."
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
 msgstr "Yazılım Merkezi"
 
 #: extension.js:88 PrefsLib/adw.js:332
@@ -138,10 +138,6 @@ msgstr ""
 msgid "Extensions Manager"
 msgstr ""
 
-#: PrefsLib/adw.js:314
-msgid "Software Center"
-msgstr "Yazılım Merkezi"
-
 #: PrefsLib/adw.js:350
 msgid "Enable Power Options"
 msgstr "Güç Seçeneklerini Etkinleştir"
@@ -207,6 +203,9 @@ msgstr ""
 #, javascript-format
 msgid "See the %sGNU General Public License, version 2 or later%s for details."
 msgstr ""
+
+#~ msgid "Software Center..."
+#~ msgstr "Yazılım Merkezi"
 
 #~ msgid "Github"
 #~ msgstr "Github"

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -1,0 +1,204 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2025 Aryan Kaushik (Aryan20)
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR Serhii Chebanenko <serhiichebanenko@yahoo.com>, 2025.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Logo Menu 34\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
+"PO-Revision-Date: 2025-02-05 16:35+0200\n"
+"Last-Translator: 4e6anenk0 <serhiichebanenko@yahoo.com>\n"
+"Language-Team: \n"
+"Language: uk_UA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.4\n"
+
+#: extension.js:75
+msgid "About My System"
+msgstr "Про систему"
+
+#: extension.js:80
+msgid "Activities"
+msgstr "Діяльність"
+
+#: extension.js:82
+msgid "App Grid"
+msgstr "Програми"
+
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
+msgstr "Центр програм"
+
+#: extension.js:88 PrefsLib/adw.js:332
+msgid "System Monitor"
+msgstr "Системний монітор"
+
+#: extension.js:89 PrefsLib/adw.js:294
+msgid "Terminal"
+msgstr "Термінал"
+
+#: extension.js:90
+msgid "Extensions"
+msgstr "Розширення"
+
+#: extension.js:94
+msgid "Force Quit App"
+msgstr "Примусово закрити програму"
+
+#: extension.js:99
+msgid "Sleep"
+msgstr "Сон"
+
+#: extension.js:100
+msgid "Restart..."
+msgstr "Перезапуск..."
+
+#: extension.js:101
+msgid "Shut Down..."
+msgstr "Вимкнути..."
+
+#: extension.js:105 extension.js:110
+msgid "Lock Screen"
+msgstr "Заблокувати екран"
+
+#: extension.js:107
+msgid "Log Out..."
+msgstr "Вийти..."
+
+#: PrefsLib/adw.js:41
+msgid "Symbolic Icons"
+msgstr "Символічні піктограми"
+
+#: PrefsLib/adw.js:45
+msgid "Coloured Icons"
+msgstr "Кольорові піктограми"
+
+#: PrefsLib/adw.js:49
+msgid "Icon Settings"
+msgstr "Налаштування піктограми"
+
+#: PrefsLib/adw.js:123
+msgid "Icon Size"
+msgstr "Розмір піктограми"
+
+#: PrefsLib/adw.js:156
+msgid "Use Custom Icon"
+msgstr "Власна піктограма"
+
+#: PrefsLib/adw.js:170
+msgid "Selected Icon"
+msgstr "Вибрана піктограма"
+
+#: PrefsLib/adw.js:195
+msgid "Select a Custom Icon"
+msgstr "Вибрати власну піктограму"
+
+#: PrefsLib/adw.js:238
+msgid "Change Defaults"
+msgstr "Змінити типові параметри"
+
+#: PrefsLib/adw.js:242
+msgid "Show/Hide Options"
+msgstr "Показати/Приховати параметри"
+
+#: PrefsLib/adw.js:246
+msgid "Top Panel Options"
+msgstr "Параметри верхньої панелі"
+
+#: PrefsLib/adw.js:254
+msgid "Icon Click Type to open Activities"
+msgstr "Тип кліку миші для огляду Діяльності"
+
+#: PrefsLib/adw.js:260
+msgid "Left Click "
+msgstr "Лівий клік "
+
+#: PrefsLib/adw.js:261
+msgid "Middle Click "
+msgstr "Клік коліщатком "
+
+#: PrefsLib/adw.js:262
+msgid "Right Click "
+msgstr "Правий клік "
+
+#: PrefsLib/adw.js:275
+msgid "Preferred Extensions Application"
+msgstr "Програма для розширень"
+
+#: PrefsLib/adw.js:281
+msgid "GNOME Extensions"
+msgstr "Розширення GNOME"
+
+#: PrefsLib/adw.js:282
+msgid "Extensions Manager"
+msgstr "Менеджер розширень"
+
+#: PrefsLib/adw.js:350
+msgid "Enable Power Options"
+msgstr "Показувати параметри вимкнення"
+
+#: PrefsLib/adw.js:365
+msgid "Hide Force Quit option"
+msgstr "Приховати примусове закриття"
+
+#: PrefsLib/adw.js:382
+msgid "Show Lock Screen option"
+msgstr "Показувати параметри блокування екрану"
+
+#: PrefsLib/adw.js:398
+msgid "Hide Software Centre option"
+msgstr "Приховати Центр Програм"
+
+#: PrefsLib/adw.js:414
+msgid "Show Activities Button"
+msgstr "Показувати кнопку Діяльність"
+
+#: PrefsLib/adw.js:430
+msgid "Hide Icon Shadow"
+msgstr "Приховати тінь піктограми"
+
+#: PrefsLib/adw.js:471 PrefsLib/adw.js:476
+msgid "About"
+msgstr "Подробиці"
+
+#: PrefsLib/adw.js:500
+msgid "Logo Menu"
+msgstr ""
+
+#: PrefsLib/adw.js:507
+msgid "Quick access menu for GNOME"
+msgstr "Меню швидкого доступу для GNOME"
+
+#: PrefsLib/adw.js:524
+msgid "Logo Menu Version"
+msgstr "Версія Logo Menu"
+
+#: PrefsLib/adw.js:536
+msgid "GNOME Version"
+msgstr "Версія GNOME"
+
+#: PrefsLib/adw.js:543
+msgid "Created with love by"
+msgstr "Зроблено з любов'ю"
+
+#: PrefsLib/adw.js:550
+msgid "Matrix/Element room"
+msgstr "Кімната Matrix/Element"
+
+#: PrefsLib/adw.js:566
+msgid "Contributors"
+msgstr "Учасники"
+
+#: PrefsLib/adw.js:583
+msgid "This program comes with absolutely no warranty."
+msgstr "Ця програма постачається без жодних гарантій."
+
+#: PrefsLib/adw.js:584
+#, javascript-format
+msgid "See the %sGNU General Public License, version 2 or later%s for details."
+msgstr "Докладніше дивіться %sGNU General Public License, версії 2 або новіше%s."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Logo Menu 18\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 05:04+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: 2022-11-17 23:24+0530\n"
 "Last-Translator: 天上飞机最快 地上表姐最坏 <trampover@gmail.com>\n"
 "Language-Team: \n"
@@ -30,8 +30,8 @@ msgstr "活动"
 msgid "App Grid"
 msgstr "所有软件"
 
-#: extension.js:86
-msgid "Software Center..."
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
 msgstr "软件中心"
 
 #: extension.js:88 PrefsLib/adw.js:332
@@ -138,10 +138,6 @@ msgstr ""
 msgid "Extensions Manager"
 msgstr ""
 
-#: PrefsLib/adw.js:314
-msgid "Software Center"
-msgstr "软件中心"
-
 #: PrefsLib/adw.js:350
 msgid "Enable Power Options"
 msgstr "显示电源选项"
@@ -207,6 +203,9 @@ msgstr ""
 #, javascript-format
 msgid "See the %sGNU General Public License, version 2 or later%s for details."
 msgstr ""
+
+#~ msgid "Software Center..."
+#~ msgstr "软件中心"
 
 #~ msgid "Icon"
 #~ msgstr "图标"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Logo Menu 18\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-17 05:04+0530\n"
+"POT-Creation-Date: 2025-01-19 01:47+0530\n"
 "PO-Revision-Date: 2022-11-17 23:24+0530\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -30,8 +30,8 @@ msgstr "活動"
 msgid "App Grid"
 msgstr "應用程式"
 
-#: extension.js:86
-msgid "Software Center..."
+#: extension.js:86 PrefsLib/adw.js:314
+msgid "Software Center"
 msgstr "App Store"
 
 #: extension.js:88 PrefsLib/adw.js:332
@@ -138,10 +138,6 @@ msgstr ""
 msgid "Extensions Manager"
 msgstr ""
 
-#: PrefsLib/adw.js:314
-msgid "Software Center"
-msgstr "App Store"
-
 #: PrefsLib/adw.js:350
 msgid "Enable Power Options"
 msgstr "顯示電源選項"
@@ -207,6 +203,9 @@ msgstr ""
 #, javascript-format
 msgid "See the %sGNU General Public License, version 2 or later%s for details."
 msgstr ""
+
+#~ msgid "Software Center..."
+#~ msgstr "App Store"
 
 #~ msgid "Github"
 #~ msgstr "Github"


### PR DESCRIPTION
This originates from https://github.com/ublue-os/bluefin/issues/2177.
I added an entry for documentation, while also reordering entries a tiny bit as suggested in https://github.com/ublue-os/bluefin/issues/2177#issuecomment-2628979567.
I also re-enabled the system settings entry a la MacOS like I suggested in https://github.com/ublue-os/bluefin/issues/2177#issuecomment-2639134756.

I also merged updates from the latest upstream release (as suggested in the original issue).
Note that translations for the new documentation entry are missing (I can provide them for Italian, but I'd rather not do too many things in one single PR).

Tested on a Bluefin LTS VM.