### PR TITLE
feat: add News... menu item to launch NewsFlash

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -76,6 +76,7 @@ class LogoMenuMenuButton extends PanelMenu.Button {
 
         this._addItem(new MenuItem(_('About My System'), () => this._aboutThisDistro()));
         this._addItem(new MenuItem(_('Documentation'), () => this._documentation()));
+        this._addItem(new MenuItem(_('News...'), () => this._openNewsFlash()));
         this._addItem(new PopupMenu.PopupSeparatorMenuItem());
 
         this._addItem(new MenuItem(_('System Settings...'), () => this._systemPreferences()));
@@ -185,6 +186,10 @@ class LogoMenuMenuButton extends PanelMenu.Button {
 
     _openTerminal() {
         Util.trySpawnCommandLine(this._settings.get_string('menu-button-terminal'));
+    }
+
+    _openNewsFlash() {
+        Util.trySpawnCommandLine('flatpak run io.gitlab.news_flash.NewsFlash');
     }
 
     _openDistroShelf() {


### PR DESCRIPTION
## Summary

Add "News..." menu item to the logo menu that launches NewsFlash RSS reader.

This is part of the NewsFlash integration for Bluefin (see ublue-os/bluefin#1485 and ublue-os/bluefin#3870).

## Changes

- Add `_openNewsFlash()` method to launch NewsFlash via flatpak
- Add "News..." menu item after "Documentation" with separator

## Screenshot

The menu item appears in the logo menu dropdown, allowing users to quickly access Bluefin news and announcements via NewsFlash.